### PR TITLE
Google Dataflow operator updated tests for an upcoming fix #13478

### DIFF
--- a/tests/providers/google/cloud/hooks/test_dataflow.py
+++ b/tests/providers/google/cloud/hooks/test_dataflow.py
@@ -1315,16 +1315,20 @@ class TestDataflowJob(unittest.TestCase):
         # AWAITING STATE
         (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_PENDING, None, False),
         (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_PENDING, None, False),
+        (None, DataflowJobStatus.JOB_STATE_PENDING, None, False),
         (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_PENDING, True, False),
         (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_PENDING, True, False),
+        (None, DataflowJobStatus.JOB_STATE_PENDING, True, False),
         (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_PENDING, False, True),
         (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_PENDING, False, True),
+        (None, DataflowJobStatus.JOB_STATE_PENDING, False, True),
     ])
     # fmt: on
     def test_check_dataflow_job_state_wait_until_finished(
         self, job_type, job_state, wait_until_finished, expected_result
     ):
         job = {"id": "id-2", "name": "name-2", "type": job_type, "currentState": job_state}
+        job = {key: job[key] for key in job if job[key] is not None}
         dataflow_job = _DataflowJobsController(
             dataflow=self.mock_dataflow,
             project_number=TEST_PROJECT,
@@ -1345,9 +1349,13 @@ class TestDataflowJob(unittest.TestCase):
             "Google Cloud Dataflow job name-2 has failed\\."),
         (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_FAILED,
          "Google Cloud Dataflow job name-2 has failed\\."),
+        (None, DataflowJobStatus.JOB_STATE_FAILED,
+         "Google Cloud Dataflow job name-2 has failed\\."),
         (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_UNKNOWN,
          "Google Cloud Dataflow job name-2 was unknown state: JOB_STATE_UNKNOWN"),
         (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_UNKNOWN,
+         "Google Cloud Dataflow job name-2 was unknown state: JOB_STATE_UNKNOWN"),
+        (None, DataflowJobStatus.JOB_STATE_UNKNOWN,
          "Google Cloud Dataflow job name-2 was unknown state: JOB_STATE_UNKNOWN"),
         (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_CANCELLED,
             "Google Cloud Dataflow job name-2 was cancelled\\."),
@@ -1365,6 +1373,7 @@ class TestDataflowJob(unittest.TestCase):
     # fmt: on
     def test_check_dataflow_job_state_terminal_state(self, job_type, job_state, exception_regex):
         job = {"id": "id-2", "name": "name-2", "type": job_type, "currentState": job_state}
+        job = {key: job[key] for key in job if job[key] is not None}
         dataflow_job = _DataflowJobsController(
             dataflow=self.mock_dataflow,
             project_number=TEST_PROJECT,


### PR DESCRIPTION
Updating unit tests of Dataflow operator to avoid regression for the fix in https://github.com/apache/airflow/pull/13478.

Updated tests:
 - `tests.providers.google.cloud.hooks.test_dataflow.TestDataflowJob.test_check_dataflow_job_state_wait_until_finished`
 - `tests.providers.google.cloud.hooks.test_dataflow.TestDataflowJob.test_check_dataflow_job_state_terminal_state`


Thank you for investigation and upcoming with original fix! We are interested in having this fix submitted ASAP, so if you find yourself in the situation where you don't have the capacity to finish this PR right now, please let me know - I can take it over by creating a separate PR to apache/airflow.

related: #13262
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
